### PR TITLE
Fix stereo downmixing.

### DIFF
--- a/source/sounds/SoundDecoder.cpp
+++ b/source/sounds/SoundDecoder.cpp
@@ -186,12 +186,15 @@ void SoundDecoder::Decode() {
         }
 
         //! TODO: remove this later and add STEREO support with two voices, for now we convert to MONO
+        done >>= 1;
         if(IsStereo()) {
             int16_t* monoBuf = (int16_t*)write_buf;
-            done = done >> 1;
+            done >>= 1;
 
             for(int32_t i = 0; i < done; i++)
                 monoBuf[i] = monoBuf[i << 1];
+
+            done <<= 1;
         }
 
         DCFlushRange(write_buf, done);


### PR DESCRIPTION
Without this fix that happens:
```
======================== ASAN: out-of-bounds load
Source: 0x0D0254D8: homebrew_launcher|_ZN12SoundDecoder6DecodeEv
Bad load was on address 0x10CEE778. Guessing possible issues:
Guess     Chunk      ChunkSz    Dist       ChunkOwner
Overflow  0x10CEA760 0x00004000 0x00000018 homebrew_launcher|_ZN12BufferCircle6ResizeEi
Underflow 0x10CEE780 0x00004000 0xFFFFBFF8 homebrew_launcher|_ZN12BufferCircle6ResizeEi
```
With this fix playing a mono stream still produces clipping but without the fix it's completely garbled.